### PR TITLE
Use replace instead of lineinfile for bind-address

### DIFF
--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -12,7 +12,7 @@
     - mariadb
     - backup
 
-- name: Setup Automated Backups 
+- name: Setup Automated Backups
   cron:
     name: mariadb-backup
     special_time: "{{ mariadb_backup_frequency }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,11 +23,10 @@
     - service
 
 - name: Configure | mariadb | bind-address
-  lineinfile:
-    state: present
+  replace:
     dest: /etc/mysql/my.cnf
     regexp: '^#* *bind-address'
-    line: 'bind-address = 0.0.0.0'
+    replace: 'bind-address = 0.0.0.0'
   when: mariadb_accepts_external_connections
   notify: Reload Service | mariadb
   tags:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -25,7 +25,7 @@
 - name: Configure | mariadb | bind-address
   replace:
     dest: /etc/mysql/my.cnf
-    regexp: '^#* *bind-address'
+    regexp: '^#* *bind-address.*'
     replace: 'bind-address = 0.0.0.0'
   when: mariadb_accepts_external_connections
   notify: Reload Service | mariadb


### PR DESCRIPTION
The `[galera]` section of my.cnf contains bind-address and lineinfile will only replace one instance of bind-address. Using replace should catch them all. I have no use case to determine if there are unintended side-effects so I will assume there aren't any until they come up.